### PR TITLE
Use the flatten-maven-plugin to make the plugins downloadable again

### DIFF
--- a/plugins/jnario-maven-plugin/pom.xml
+++ b/plugins/jnario-maven-plugin/pom.xml
@@ -1,19 +1,20 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>jnario-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
 	<name>Jnario Maven Plugin</name>
 	<groupId>org.jnario</groupId>
-	
+
 	<parent>
-        <relativePath>../..</relativePath>
-        <groupId>org.jnario</groupId>
-        <artifactId>jnario</artifactId>
-        <version>${revision}</version>
-    </parent>
-	
-	
+		<relativePath>../..</relativePath>
+		<groupId>org.jnario</groupId>
+		<artifactId>jnario</artifactId>
+		<version>${revision}</version>
+	</parent>
+
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
@@ -21,16 +22,16 @@
 		<version.maven>3.6.2</version.maven>
 	</properties>
 	<repositories>
-      <repository>
-        <id>xtend.release</id>
-        <url>https://oss.sonatype.org/content/repositories/central/</url>
-        <releases>
-           <enabled>true</enabled>
-        </releases>
-        <snapshots>
-          <enabled>true</enabled>
-        </snapshots>        
-     </repository>
+		<repository>
+			<id>xtend.release</id>
+			<url>https://oss.sonatype.org/content/repositories/central/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
 	</repositories>
 	<dependencies>
 		<dependency>
@@ -38,16 +39,16 @@
 			<artifactId>org.eclipse.xtext.xbase</artifactId>
 			<version>${xtext.version}</version>
 		</dependency>
-        <dependency>
-            <groupId>org.eclipse.xtext</groupId>
-            <artifactId>xtext-maven-plugin</artifactId>
-            <version>${xtext.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.xtext</groupId>
-            <artifactId>org.eclipse.xtext.smap</artifactId>
-            <version>${xtext.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>xtext-maven-plugin</artifactId>
+			<version>${xtext.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext.smap</artifactId>
+			<version>${xtext.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.jnario</groupId>
 			<artifactId>org.jnario.standalone</artifactId>
@@ -61,26 +62,24 @@
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-            <version>3.4</version>
-            <scope>provided</scope>
+			<version>3.4</version>
+			<scope>provided</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-core</artifactId>
-            <version>${version.maven}</version>
-        </dependency>
-        <!--
-        	See https://github.com/eclipse/xtext/issues/1231
-
-        	Prevents mvn build exception:
-                - SecurityException: class "org.eclipse.core.runtime.OperationCanceledException"'s signer information does not match signer information of other classes in the same package
-        -->
-        <dependency>
-            <groupId>org.eclipse.platform</groupId>
-            <artifactId>org.eclipse.equinox.common</artifactId>
-            <version>3.10.0</version>
-        </dependency>
- 	</dependencies>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-core</artifactId>
+			<version>${version.maven}</version>
+		</dependency>
+		<!-- See https://github.com/eclipse/xtext/issues/1231 Prevents mvn build 
+			exception: - SecurityException: class "org.eclipse.core.runtime.OperationCanceledException"'s 
+			signer information does not match signer information of other classes in 
+			the same package -->
+		<dependency>
+			<groupId>org.eclipse.platform</groupId>
+			<artifactId>org.eclipse.equinox.common</artifactId>
+			<version>3.10.0</version>
+		</dependency>
+	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
@@ -113,12 +112,12 @@
 			<plugin>
 				<artifactId>maven-plugin-plugin</artifactId>
 				<version>3.5.2</version>
-                <executions>
-                    <execution>
-                        <id>default-descriptor</id>
-                        <phase>process-classes</phase>
-                    </execution>
-                </executions>
+				<executions>
+					<execution>
+						<id>default-descriptor</id>
+						<phase>process-classes</phase>
+					</execution>
+				</executions>
 				<configuration>
 					<goalPrefix>jnario</goalPrefix>
 				</configuration>
@@ -160,10 +159,36 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.2.1</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>
@@ -201,19 +226,22 @@
 		<license>
 			<name>Eclipse Public License v1.0</name>
 			<comments>
-			All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.htm
-			</comments>
+			All rights reserved. This program and the accompanying
+			materials are made available under the terms of the Eclipse Public
+			License v1.0 which accompanies this distribution, and is available at
+			http://www.eclipse.org/legal/epl-v10.htm
+		</comments>
 		</license>
 	</licenses>
 	<url>
-		http://www.jnario.org/
-	</url>
+	http://www.jnario.org/
+</url>
 	<inceptionYear>2012</inceptionYear>
 	<issueManagement>
 		<system>Github Issues</system>
 		<url>
-https://github.com/sebastianbenz/Jnario/issues
-</url>
+		https://github.com/sebastianbenz/Jnario/issues
+	</url>
 	</issueManagement>
 	<organization>
 		<name>BMW Car IT</name>

--- a/plugins/jnario-maven-report-plugin/pom.xml
+++ b/plugins/jnario-maven-report-plugin/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>report</artifactId>
@@ -6,12 +7,12 @@
 	<name>Jnario Maven Report Plugin</name>
 	<groupId>org.jnario</groupId>
 
-    <parent>
-        <relativePath>../..</relativePath>
-        <groupId>org.jnario</groupId>
-        <artifactId>jnario</artifactId>
-        <version>${revision}</version>
-    </parent>
+	<parent>
+		<relativePath>../..</relativePath>
+		<groupId>org.jnario</groupId>
+		<artifactId>jnario</artifactId>
+		<version>${revision}</version>
+	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -43,7 +44,7 @@
 			<artifactId>jnario-maven-plugin</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
@@ -79,26 +80,50 @@
 			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.4</version>
-            <scope>provided</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>3.4</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
 			<plugin>
 				<artifactId>maven-plugin-plugin</artifactId>
 				<version>3.5.2</version>
-                <executions>
-                    <execution>
-                        <id>default-descriptor</id>
-                        <phase>process-classes</phase>
-                    </execution>
-                </executions>
+				<executions>
+					<execution>
+						<id>default-descriptor</id>
+						<phase>process-classes</phase>
+					</execution>
+				</executions>
 				<configuration>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.2.1</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -167,7 +192,8 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>

--- a/plugins/org.jnario.standalone.maven/pom.xml
+++ b/plugins/org.jnario.standalone.maven/pom.xml
@@ -79,8 +79,33 @@
 			</exclusions>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.2.1</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>1.7</version>

--- a/plugins/org.jnario.standalone/pom.xml
+++ b/plugins/org.jnario.standalone/pom.xml
@@ -13,6 +13,4 @@
 	<artifactId>org.jnario.standalone</artifactId>
 	<groupId>org.jnario.plugin</groupId>
 	<packaging>eclipse-plugin</packaging>
-
-
 </project>


### PR DESCRIPTION
The parent ${revision} do not work when pushed to a artifact repo.
With the flatten plugin necessary stuff from the parent is merged to the uploaded artifacts.